### PR TITLE
DO NOT MERGE [Shop] Disable role mention auto-sanitizer when sending pinging message

### DIFF
--- a/shop/shop.py
+++ b/shop/shop.py
@@ -20,6 +20,7 @@ from .checks import Checks
 import discord
 
 # Red
+from redbot import VersionInfo, version_info
 from redbot.core import Config, bank, commands
 from redbot.core.data_manager import bundled_data_path
 
@@ -29,6 +30,11 @@ __version__ = "3.1.06"
 __author__ = "Redjumpman"
 
 BaseCog = getattr(commands, "Cog", object)
+
+if version_info < VersionInfo.from_str("3.3.2"):
+    SANITIZE_ROLES_KWARG = {}
+else:
+    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 
 def global_permissions():
@@ -734,7 +740,7 @@ class Shop(BaseCog):
             role = discord.utils.get(ctx.guild.roles, name=alert_role)
             if role:
                 msg = "{}\n{}".format(role.mention, msg)
-        await ctx.send(msg)
+        await ctx.send(msg, **SANITIZE_ROLES_KWARG)
 
     async def change_mode(self, mode):
         await self.db.clear_all()

--- a/shop/shop.py
+++ b/shop/shop.py
@@ -31,7 +31,7 @@ __author__ = "Redjumpman"
 
 BaseCog = getattr(commands, "Cog", object)
 
-if version_info < VersionInfo.from_str("3.3.2"):
+if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}


### PR DESCRIPTION
Starting with Red 3.4.0, `ctx.send` will automatically sanitize role mentions in message's content to avoid mass-mentioning people by accident. This behavior can be disabled with `sanitize_roles` kwarg set to `False`.
This PR adds that kwarg to `ctx.send` call when Red version is higher than or equal to 3.4.0.
This version hasn't been released just yet, but the change was already merged in develop version which means it's a matter of max few days before the 3.4.0 release happens so you might be interested in having the fix ready in time and this PR keeps the backwards-compatibility so you don't have to worry about merging it before the release.

Edit: it's a little less known now whether we will add this in 3.4.0 or not so I suggest not merging this for now, see PR: https://github.com/Cog-Creators/Red-DiscordBot/pull/3625
