### PR TITLE
[Pokedex] 1 bug fix and 1 improvement in usage example for [p]pokemon tmset command

### DIFF
--- a/pokedex/pokedex.py
+++ b/pokedex/pokedex.py
@@ -19,7 +19,7 @@ from redbot.core.utils.chat_formatting import box
 from tabulate import tabulate
 
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 __author__ = "Redjumpman"
 
 switcher = {

--- a/pokedex/pokedex.py
+++ b/pokedex/pokedex.py
@@ -57,7 +57,6 @@ exceptions = (
 
 tm_exceptions = (
     "Beldum",
-    "Burmy",
     "Cascoon",
     "Caterpie",
     "Combee",
@@ -219,8 +218,11 @@ class Pokedex(commands.Cog):
 
     @pokemon.command()
     async def tmset(self, ctx, *, pokemon: str):
-        """Get a Pokémon's learnset by generation(1-7).
-          Example: !pokedex tmset V pikachu """
+        """Get a Pokémon's learnset by generation (1-7).
+
+            Example: [p]pokedex tmset pikachu-5
+            If the generation is not specified, it will default to the latest generation.
+        """
         pokemon, generation = self.clean_output(pokemon)
 
         if pokemon.title() in tm_exceptions:


### PR DESCRIPTION
Fixed a bug where bot won't show tmset stats for "Burmy" pokémon.
Reference with bulbapedia for TM learnset stats for Burmy: [Gen VI](https://bulbapedia.bulbagarden.net/wiki/Burmy_(Pok%C3%A9mon)/Generation_VI_learnset#By_TM.2FHM) and [Gen VII](https://bulbapedia.bulbagarden.net/wiki/Burmy_(Pok%C3%A9mon)/Generation_VII_learnset#By_TM).

Corrected and improved the usage example for `[p]pokemon tmset` command shown in autohelp.