### PR TITLE
Added summation of values for dicetable

### DIFF
--- a/dicetable/dicetable.py
+++ b/dicetable/dicetable.py
@@ -67,6 +67,14 @@ class DiceTable(commands.Cog):
             for idx, x in enumerate(range(1, times + 1))
         ]
         final = [x + (str(x[1] + modifier),) for x in rolls]
+
+        # Add row at bottom to show sums
+        sum_total = sum([int(x[1] + modifier) for x in rolls])
+        sum_base = sum([int(x[1]) for x in rolls])
+        sum_modifier = int(modifier) * len(rolls)
+        sum_row = ("Sum:", sum_base, sum_modifier, sum_total)
+        final.append(sum_row)
+
         headers = ["Roll", "Result", "Modifier", "Total"]
         t = "**Dice:** {}\n```{}```".format(dice, tabulate(final, headers=headers))
         embed = discord.Embed(title="Dice Table Output", color=0x3366FF)


### PR DESCRIPTION
I figured a bottom row for summing the values of all the rolls would be beneficial. One example I have is rolling in DnD for multiple attacks where the DM would want to know the total damage done rather than do the math themselves.

For this example image, I did `[p]dtable roll 4d6 2 3`, which would be a similar situation where you had 2 attacks of 4d6 with a +3 modifier, and wanted to know the sum of total damage rather than adding it up yourself.
I also made added summation for the base rolls (just the 4d6 without any modifier) as well as the summation of the modifier (so modifier * number of rolls, or in this case 3*2).
![image](https://user-images.githubusercontent.com/14364070/92673167-7b1c2d00-f2e8-11ea-982a-18133c530e8d.png)
