### PR TITLE
[Coupon] Add `import discord`

### DIFF
--- a/coupon/coupon.py
+++ b/coupon/coupon.py
@@ -1,4 +1,5 @@
 import uuid
+import discord
 
 from redbot.core import bank, checks, commands, Config
 from redbot.core.utils.chat_formatting import box, pagify


### PR DESCRIPTION
Previously, would throw error on the try-except, as `discord.Forbidden` is not available w/o discord