### PR TITLE
[Casino] Fix loading with dpy2

### DIFF
--- a/casino/__init__.py
+++ b/casino/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = "This cog stores discord IDs as needed for ope
 
 async def setup(bot):
     cog = Casino(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)
     await cog.initialise()

--- a/casino/casino.py
+++ b/casino/casino.py
@@ -425,7 +425,7 @@ class Casino(Database, commands.Cog):
         cmd_list2 = "\n".join(["**{}** - {}".format(x, y) for x, y in cmd_list2])
         wiki = "[Casino Wiki](https://github.com/Redjumpman/Jumper-Plugins/wiki/Casino-RedV3)"
         embed = discord.Embed(colour=0xFF0000, description=wiki)
-        embed.set_author(name="Casino Admin Panel", icon_url=ctx.bot.user.avatar_url)
+        embed.set_author(name="Casino Admin Panel", icon_url=ctx.bot.user.display_avatar.url)
         embed.add_field(name="__Casino__", value=cmd_list)
         embed.add_field(name="__Casino Settings__", value=cmd_list2)
         embed.set_footer(text=_("With great power, comes great responsibility."))
@@ -504,7 +504,7 @@ class Casino(Database, commands.Cog):
         # Embed
         embed = discord.Embed(colour=color, description=description)
         embed.title = _("{} Casino").format(casino_name)
-        embed.set_author(name=str(player), icon_url=player.avatar_url)
+        embed.set_author(name=str(player), icon_url=player.display_avatar.url)
         embed.add_field(name="\u200b", value="\u200b")
         embed.add_field(name="-" * 65, value=box(table, lang="md"))
         embed.set_footer(text=disclaimer)


### PR DESCRIPTION
This PR will:
- Fix the `add_cog` call in casino to use `await`, as it is now a coroutine.
- `s/avatar_url/display_avatar.url`, since `avatar`/`display_avatar` are `discord.Asset`s with a `url` attribute, but `avatar` may be `None`.